### PR TITLE
fixed extra slash in imageUrl

### DIFF
--- a/app/code/local/Edge/Base/Helper/Image.php
+++ b/app/code/local/Edge/Base/Helper/Image.php
@@ -4,12 +4,13 @@ class Edge_Base_Helper_Image extends Mage_Core_Helper_Abstract
 {
     public function getImage($file)
     {
-        if (($file) && (0 !== strpos($file, '/', 0))) {
-            $file = '/' . $file;
-        }
-
         $mediaDir = Mage::getBaseDir('media');
-        $imageDir = $mediaDir . $file;
+        
+        if (($file) && (0 !== strpos($file, '/', 0))) {
+            $mediaDir = $mediaDir . '/';
+        }
+        
+        $imageDir = $mediaDir . $file;        
 
         if (!file_exists($imageDir)){
             // If the file does not exist, create it from the database


### PR DESCRIPTION
Mage::getBaseUrl('media') has a slash to the end of the URL unlike Mage::getBaseDir('media'). This was causing an extra slash in the image URL betwen the media url and file path.